### PR TITLE
Add caching logic for getting a full trace.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.spotify.tracing'
-version = System.getenv('CIRCLE_TAG') ?: System.getenv('DOCKER_TAG') ?: '0.0.1-SNAPSHOT'
+version = System.getenv('CIRCLE_TAG') ?: System.getenv('DOCKER_TAG') ?: '0.1.0-SNAPSHOT'
 
 repositories {
     mavenLocal()
@@ -19,11 +19,11 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"
 
     implementation "io.opencensus:opencensus-api:0.24.0"
+    implementation "com.github.ben-manes.caffeine:caffeine:2.8.1"
 
     def junit_version = '5.6.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
-
     testImplementation "io.mockk:mockk:1.9"
 }
 


### PR DESCRIPTION
This will collect spans until either a span with no parent or an external parent is seen for the trace before attempting a squash. This logic should capture the full trace unless the span end timing is incorrect, as children will always finish before their parents.

The performance of the squash is not good when being given many spans - testing with Heroic running locally, 131644 spans were squashed down to 9 but it took 38 seconds to actually do so. This is for a trace encompassing 3.5 minutes of data. I added #2 to look into possible improvements.

Closes #1 